### PR TITLE
Gen modification

### DIFF
--- a/backend/crates/eiffelvis_gen/src/generator.rs
+++ b/backend/crates/eiffelvis_gen/src/generator.rs
@@ -79,7 +79,7 @@ impl Default for EventGenerator {
         Self {
             inner: Inner {
                 event_set: EventSet::default(),
-                max_links: 5,
+                max_links: 10,
                 history_max: 100,
             },
             seed: rand::random::<usize>().into(),
@@ -223,11 +223,11 @@ impl Iterator for Iter<'_> {
             "TCT", "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS"];
             
         // Random number generator used to select a random index of the above
-        fn random_num() -> usize{
+        fn random_num(min: usize, max: usize) -> usize{
             let mut rng = rand::thread_rng();
-            return rng.gen_range(0..22);
+            return rng.gen_range(min..max);
         }
-
+        
         // Randomly pick a link and select an event for it until we reach our target or we exhaust possible events
         while let Some((i, (link, _))) = {
             let ret = generatable_events
@@ -236,9 +236,10 @@ impl Iterator for Iter<'_> {
                 .choose(&mut *self.rng.borrow_mut());
             ret
         } {
+            
             if generated_links.len() >= target_amount {
                 break;
-            }
+            }         
 
             let exhausted = if let Some(bl) = select_event(*link) {
                 generated_links.push(bl);
@@ -252,7 +253,7 @@ impl Iterator for Iter<'_> {
             }
         }
 
-        event.meta.event_type = event_types[random_num()].to_string();
+        event.meta.event_type = event_types[random_num(0, 22)].to_string();
         event.meta.id = Uuid::from_bytes(self.rng.get_mut().gen());
 
         event.meta.time = SystemTime::now()

--- a/backend/crates/eiffelvis_gen/src/generator.rs
+++ b/backend/crates/eiffelvis_gen/src/generator.rs
@@ -217,17 +217,18 @@ impl Iterator for Iter<'_> {
             .borrow_mut()
             .gen_range(0..self.inner.max_links - generated_links.len());
 
+        // List of possible eiffel events
+        let event_types: [&str; 23] = [
+            "ActC", "ActF", "ActS", "ActT", "AnnP", "ArtC", "ArtP", "ArtR", "TCC", "TCF", "TCS",
+            "TCT", "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS",
+        ];
 
-        // List of possible eiffel events 
-        let event_types: [&str; 23] = ["ActC", "ActF", "ActS", "ActT", "AnnP", "ArtC", "ArtP", "ArtR", "TCC", "TCF", "TCS",
-            "TCT", "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS"];
-            
         // Random number generator used to select a random index of the above
-        fn random_num(min: usize, max: usize) -> usize{
+        fn random_num(min: usize, max: usize) -> usize {
             let mut rng = rand::thread_rng();
-            return rng.gen_range(min..max);
+            rng.gen_range(min..max)
         }
-        
+
         // Randomly pick a link and select an event for it until we reach our target or we exhaust possible events
         while let Some((i, (link, _))) = {
             let ret = generatable_events
@@ -236,10 +237,9 @@ impl Iterator for Iter<'_> {
                 .choose(&mut *self.rng.borrow_mut());
             ret
         } {
-            
             if generated_links.len() >= target_amount {
                 break;
-            }         
+            }
 
             let exhausted = if let Some(bl) = select_event(*link) {
                 generated_links.push(bl);

--- a/backend/crates/eiffelvis_gen/src/generator.rs
+++ b/backend/crates/eiffelvis_gen/src/generator.rs
@@ -217,6 +217,17 @@ impl Iterator for Iter<'_> {
             .borrow_mut()
             .gen_range(0..self.inner.max_links - generated_links.len());
 
+
+        // List of possible eiffel events 
+        let event_types: [&str; 23] = ["ActC", "ActF", "ActS", "ActT", "AnnP", "ArtC", "ArtP", "ArtR", "TCC", "TCF", "TCS",
+            "TCT", "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS"];
+            
+        // Random number generator used to select a random index of the above
+        fn random_num() -> usize{
+            let mut rng = rand::thread_rng();
+            return rng.gen_range(0..22);
+        }
+
         // Randomly pick a link and select an event for it until we reach our target or we exhaust possible events
         while let Some((i, (link, _))) = {
             let ret = generatable_events
@@ -241,7 +252,7 @@ impl Iterator for Iter<'_> {
             }
         }
 
-        event.meta.event_type = meta_event.name().to_string();
+        event.meta.event_type = event_types[random_num()].to_string();
         event.meta.id = Uuid::from_bytes(self.rng.get_mut().gen());
 
         event.meta.time = SystemTime::now()

--- a/backend/crates/eiffelvis_gen/src/generator.rs
+++ b/backend/crates/eiffelvis_gen/src/generator.rs
@@ -217,18 +217,6 @@ impl Iterator for Iter<'_> {
             .borrow_mut()
             .gen_range(0..self.inner.max_links - generated_links.len());
 
-        // List of possible eiffel events
-        let event_types: [&str; 23] = [
-            "ActC", "ActF", "ActS", "ActT", "AnnP", "ArtC", "ArtP", "ArtR", "TCC", "TCF", "TCS",
-            "TCT", "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS",
-        ];
-
-        // Random number generator used to select a random index of the above
-        fn random_num(min: usize, max: usize) -> usize {
-            let mut rng = rand::thread_rng();
-            rng.gen_range(min..max)
-        }
-
         // Randomly pick a link and select an event for it until we reach our target or we exhaust possible events
         while let Some((i, (link, _))) = {
             let ret = generatable_events
@@ -253,7 +241,7 @@ impl Iterator for Iter<'_> {
             }
         }
 
-        event.meta.event_type = event_types[random_num(0, 22)].to_string();
+        event.meta.event_type = meta_event.name().to_string();
         event.meta.id = Uuid::from_bytes(self.rng.get_mut().gen());
 
         event.meta.time = SystemTime::now()

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -87,13 +87,13 @@ async fn app() -> anyhow::Result<()> {
 
     let channel_a = conn.create_channel().await?;
 
-    let queue = channel_a
-            .queue_declare(
-                "hello",
-                QueueDeclareOptions::default(),
-                FieldTable::default(),
-            )
-            .await?;
+    channel_a
+        .queue_declare(
+            "hello",
+            QueueDeclareOptions::default(),
+            FieldTable::default(),
+        )
+        .await?;
 
         // println!(?queue, "Declared queue");
     println!("Connected to broker.");

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -15,6 +15,11 @@ use lapin::{options::*, types::FieldTable, BasicProperties, Connection, Connecti
 use clap::Parser;
 use rand::{thread_rng, Rng};
 
+const EVENT_TYPES: [&str; 23] = [
+    "ActC", "ActF", "ActS", "ActT", "AnnP", "ArtC", "ArtP", "ArtR", "TCC", "TCF", "TCS", "TCT",
+    "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS",
+];
+
 #[derive(Parser)]
 #[clap(about = "Generates random events and sends them over ampq")]
 struct Cli {
@@ -98,18 +103,23 @@ async fn app() -> anyhow::Result<()> {
     // println!(?queue, "Declared queue");
     println!("Connected to broker.");
 
+    let mut builder = EventSet::build();
+
+    for i in EVENT_TYPES {
+        builder = builder.add_event(
+            Event::new(i.to_string(), "1.0.0")
+                .with_link("Link0")
+                .with_link("Link1"),
+        );
+    }
+
     let gen = EventGenerator::new(
         cli.seed.unwrap_or_else(|| thread_rng().gen::<usize>()),
         6,
         8,
-        EventSet::build()
+        builder
             .add_link(Link::new("Link0", true))
             .add_link(Link::new("Link1", true))
-            .add_event(
-                Event::new("Event", "1.0.0")
-                    .with_link("Link0")
-                    .with_link("Link1"),
-            )
             .build()
             .expect("This should work"),
     );

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -105,18 +105,25 @@ async fn app() -> anyhow::Result<()> {
 
     let mut builder = EventSet::build();
 
-    for i in EVENT_TYPES {
-        builder = builder.add_event(
-            Event::new(i.to_string(), "1.0.0")
-                .with_link("Link0")
-                .with_link("Link1"),
-        );
+    for eventtype in EVENT_TYPES {
+        // Initialize and create the event variable
+        let mut event = Event::new(eventtype.to_string(), "1.0.0");
+
+        // Create the random number generate for the links
+        let _randomrange = rand::thread_rng().gen_range(1..3);
+
+        // Loop and add the links to the event
+        for linknumber in 0.._randomrange {
+            event = event.with_link(format!("Link{linknumber}"));
+        }
+
+        builder = builder.add_event(event);
     }
 
     let gen = EventGenerator::new(
         cli.seed.unwrap_or_else(|| thread_rng().gen::<usize>()),
-        6,
-        8,
+        16,
+        18,
         builder
             .add_link(Link::new("Link0", true))
             .add_link(Link::new("Link1", true))

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -2,6 +2,7 @@ use std::{
     fs::File,
     io::{BufRead, BufReader},
     time::Duration,
+    time::Instant,
 };
 
 use eiffelvis_gen::{
@@ -18,7 +19,7 @@ use rand::{thread_rng, Rng};
 #[clap(about = "Generates random events and sends them over ampq")]
 struct Cli {
     /// Total amount of events to be sent (note: multiplied with the `burst` option)
-    #[clap(default_value = "3", short, long)]
+    #[clap(default_value = "300", short, long)]
     count: usize,
 
     /// URL to amqp server
@@ -83,7 +84,7 @@ async fn app() -> anyhow::Result<()> {
 
         // println!(?queue, "Declared queue");
     println!("Connected to broker.");
-    let typeArray = ["Event1","Event2","Event3","Event4","Event5"];
+    let type_Array = ["Event1","Event2","Event3","Event4","Event5"];
     
     let gen = EventGenerator::new(
         cli.seed.unwrap_or_else(|| thread_rng().gen::<usize>()),
@@ -93,7 +94,7 @@ async fn app() -> anyhow::Result<()> {
             .add_link(Link::new("Link0", true))
             .add_link(Link::new("Link1", true))
             .add_event(
-                Event::new(typeArray[rand::thread_rng().gen_range(0..4)] , "1.0.0")
+                Event::new(type_Array[rand::thread_rng().gen_range(0..4)] , "1.0.0")
                     .with_link("Link0")
                     .with_link("Link1"),
             )
@@ -113,40 +114,62 @@ async fn app() -> anyhow::Result<()> {
     };
 
     let target = cli.count * cli.burst;
-    let sleep_duration = Duration::from_millis(cli.latency as u64);
+
+    // Random number generator used to product random intervals 
+    fn random_num(from:usize, to:usize) -> usize{
+        let mut rng = rand::thread_rng();
+        return rng.gen_range(from..to);
+    }
 
     println!(
-        "Sending out ~{} events, {} events every {}ms interval",
-        target, cli.burst, cli.latency
+        "Sending out a maximum of {} events, over a maximum duration of {} seconds. \nEvents sent at random intervals between 5-220ms. \nProcess will stop at whichever comes first.\n",
+        target, ((target*120) / 1000)
     );
 
     let mut sent = 0;
-    for _ in 0..(target) {
-        let mut taken = 0;
-        for ev in (&mut iter).take(cli.burst) {
-            let _ = channel_a
-                .basic_publish(
-                    cli.exchange.as_str(),
-                    cli.routing_key.as_str(),
-                    BasicPublishOptions::default(),
-                    ev.as_slice(),
-                    BasicProperties::default(),
-                )
-                .await?
-                .await?;
-            taken += 1;
-        }
-        if cli.burst > taken {
-            println!("Exhausted source, stopping early!");
-            break;
-        }
-        sent += taken;
-        if sleep_duration.as_millis() > 0 {
-            tokio::time::sleep(sleep_duration).await;
+    // Used for a time reference staring point
+    let start = Instant::now();
+    // Factor to calculate the total duration from the event count
+    let factor = 120;
+    // Total duration is = to the count multiplied by 120 (30000 events will be sent over and hour)
+    let total_duration = cli.count * factor;
+    // Decalred as mut in order to allow the value to change
+    let mut duration = start.elapsed();
+
+        for _ in 0..(target) {
+            // Loop until the elapsed time has reached the calculated total duration or event count has been reached
+            while duration.as_millis() < total_duration.try_into().unwrap() && sent < cli.count{
+                // Generate a random delay between 5 and 220ms
+                let pause_duration = Duration::from_millis(random_num(5, 215) as u64);
+                //println!("Pause duration: {:?}", pause_duration); 
+
+                let mut taken = 0;
+                for ev in (&mut iter).take(cli.burst) {
+                    let _ = channel_a
+                        .basic_publish(
+                            cli.exchange.as_str(),
+                            cli.routing_key.as_str(),
+                            BasicPublishOptions::default(),
+                            ev.as_slice(),
+                            BasicProperties::default(),
+                        )
+                        .await?
+                        .await?;
+                    taken += 1;
+                }
+                if cli.burst > taken {
+                    println!("Exhausted source, stopping early!");
+                    break;
+                }
+                sent += taken;
+
+                // Sleep for a randomly selected time
+                tokio::time::sleep(pause_duration).await;
+                // Stores the amount of time elapsed from the start.
+                duration = start.elapsed();
         }
     }
-
-    println!("Done, sent {} events", sent);
+    println!("Done! Total events sent: {}, total duration: {:?}", sent, duration);
 
     Ok(())
 }

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -157,39 +157,44 @@ async fn app() -> anyhow::Result<()> {
 
     let t_duration = cli.total_duration.try_into().unwrap();
 
-    for _ in 0..(target) {
-        // Additional duration condition to break out of the loop if total duration has been reached
-        if run_duration.as_millis() < t_duration {
-            // Generate a random delay between 5 and 220ms
-            let pause_duration = Duration::from_millis(
-                rand::thread_rng().gen_range(cli.min_latency..cli.latency_max) as u64,
-            );
-            let mut taken = 0;
-            for ev in (&mut iter).take(cli.burst) {
-                let _ = channel_a
-                    .basic_publish(
-                        cli.exchange.as_str(),
-                        cli.routing_key.as_str(),
-                        BasicPublishOptions::default(),
-                        ev.as_slice(),
-                        BasicProperties::default(),
-                    )
-                    .await?
-                    .await?;
-                taken += 1;
-            }
-            if cli.burst > taken {
-                println!("Exhausted source, stopping early!");
+    // Condition check to ensure min-latency is not greater than latency-max
+    if cli.min_latency <= cli.latency_max {
+        for _ in 0..(target) {
+            // Additional duration condition to break out of the loop if total duration has been reached
+            if run_duration.as_millis() < t_duration {
+                // Generate a random delay between 5 and 220ms
+                let pause_duration = Duration::from_millis(
+                    rand::thread_rng().gen_range(cli.min_latency..=cli.latency_max) as u64,
+                );
+                let mut taken = 0;
+                for ev in (&mut iter).take(cli.burst) {
+                    let _ = channel_a
+                        .basic_publish(
+                            cli.exchange.as_str(),
+                            cli.routing_key.as_str(),
+                            BasicPublishOptions::default(),
+                            ev.as_slice(),
+                            BasicProperties::default(),
+                        )
+                        .await?
+                        .await?;
+                    taken += 1;
+                }
+                if cli.burst > taken {
+                    println!("Exhausted source, stopping early!");
+                    break;
+                }
+                sent += taken;
+                // Sleep for a randomly selected time
+                tokio::time::sleep(pause_duration).await;
+                // Stores the amount of time elapsed from the start.
+                run_duration = start.elapsed();
+            } else {
                 break;
             }
-            sent += taken;
-            // Sleep for a randomly selected time
-            tokio::time::sleep(pause_duration).await;
-            // Stores the amount of time elapsed from the start.
-            run_duration = start.elapsed();
-        } else {
-            break;
         }
+    } else {
+        println!("Stopping early! - min-latency can not be greater than latency-max.\nTo have a fixed latency enter both as the same value\n");
     }
     println!(
         "Done! Total events sent: {}, total duration: {:?}",

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -18,9 +18,18 @@ use rand::{thread_rng, Rng};
 #[derive(Parser)]
 #[clap(about = "Generates random events and sends them over ampq")]
 struct Cli {
-    /// Total amount of events to be sent (note: multiplied with the `burst` option)
-    #[clap(default_value = "300", short, long)]
+
+    // NOTE: The number of events along with the total duration, min lacency and latency max is to be used for stress testing.
+    // When setting these values, keep in mind that the generator process will stop at whichever value is reached first (between the count and total duration).
+    // The defaut settings on these variables represent roughly 30,000 events sent per hour.
+ 
+    // Total amount of events to be sent (note: multiplied with the `burst` option)
+    #[clap(default_value = "30000", short, long)]
     count: usize,
+
+    // Total duration to run the event generator
+    #[clap(default_value = "3600000", short, long)]
+    total_duration: usize,
 
     /// URL to amqp server
     #[clap(default_value = "amqp://127.0.0.1:5672/%2f", short, long)]
@@ -38,9 +47,13 @@ struct Cli {
     #[clap(long)]
     seed: Option<usize>,
 
-    /// Time in milliseconds to sleep before emitting a new burst of events
+    /// Starting latency value for the random interval between events
     #[clap(default_value = "5", short, long)]
-    latency: usize,
+    min_latency: usize,
+
+    /// Ending latency value for the random interval between events
+    #[clap(default_value = "220", short, long)]
+    latency_max: usize,
 
     /// Amount of events to send before introducing another delay (defined with the latency option)
     #[clap(default_value = "1", short, long)]
@@ -84,7 +97,6 @@ async fn app() -> anyhow::Result<()> {
 
         // println!(?queue, "Declared queue");
     println!("Connected to broker.");
-    let type_Array = ["Event1","Event2","Event3","Event4","Event5"];
     
     let gen = EventGenerator::new(
         cli.seed.unwrap_or_else(|| thread_rng().gen::<usize>()),
@@ -94,7 +106,7 @@ async fn app() -> anyhow::Result<()> {
             .add_link(Link::new("Link0", true))
             .add_link(Link::new("Link1", true))
             .add_event(
-                Event::new(type_Array[rand::thread_rng().gen_range(0..4)] , "1.0.0")
+                Event::new("Event" , "1.0.0")
                     .with_link("Link0")
                     .with_link("Link1"),
             )
@@ -122,26 +134,21 @@ async fn app() -> anyhow::Result<()> {
     }
 
     println!(
-        "Sending out a maximum of {} events, over a maximum duration of {} seconds. \nEvents sent at random intervals between 5-220ms. \nProcess will stop at whichever comes first.\n",
-        target, ((target*120) / 1000)
+        "\nSending out a maximum of {} events, over a maximum duration of {} seconds. \nProcess will stop at whichever comes first. \nEvents sent at random intervals between {}-{}ms. \n",
+        target, (cli.total_duration / 1000), cli.min_latency, cli.latency_max
     );
 
     let mut sent = 0;
     // Used for a time reference staring point
     let start = Instant::now();
-    // Factor to calculate the total duration from the event count
-    let factor = 120;
-    // Total duration is = to the count multiplied by 120 (30000 events will be sent over and hour)
-    let total_duration = cli.count * factor;
     // Decalred as mut in order to allow the value to change
     let mut duration = start.elapsed();
 
         for _ in 0..(target) {
             // Loop until the elapsed time has reached the calculated total duration or event count has been reached
-            while duration.as_millis() < total_duration.try_into().unwrap() && sent < cli.count{
+            while duration.as_millis() < cli.total_duration.try_into().unwrap() && sent < cli.count{
                 // Generate a random delay between 5 and 220ms
-                let pause_duration = Duration::from_millis(random_num(5, 215) as u64);
-                //println!("Pause duration: {:?}", pause_duration); 
+                let pause_duration = Duration::from_millis(random_num(cli.min_latency, cli.latency_max) as u64);
 
                 let mut taken = 0;
                 for ev in (&mut iter).take(cli.burst) {

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -122,8 +122,8 @@ async fn app() -> anyhow::Result<()> {
 
     let gen = EventGenerator::new(
         cli.seed.unwrap_or_else(|| thread_rng().gen::<usize>()),
-        16,
-        18,
+        8,
+        10,
         builder
             .add_link(Link::new("Link0", true))
             .add_link(Link::new("Link1", true))
@@ -144,12 +144,6 @@ async fn app() -> anyhow::Result<()> {
 
     let target = cli.count * cli.burst;
 
-    // Random number generator used to product random intervals
-    fn random_num(from: usize, to: usize) -> usize {
-        let mut rng = rand::thread_rng();
-        rng.gen_range(from..to)
-    }
-
     println!(
         "\nSending out a maximum of {} events, over a maximum duration of {} seconds. \nProcess will stop at whichever comes first. \nEvents sent at random intervals between {}-{}ms. \n",
         target, (cli.total_duration / 1000), cli.min_latency, cli.latency_max
@@ -159,15 +153,17 @@ async fn app() -> anyhow::Result<()> {
     // Used for a time reference staring point
     let start = Instant::now();
     // Decalred as mut in order to allow the value to change
-    let mut duration = start.elapsed();
+    let mut run_duration = start.elapsed();
+
+    let t_duration = cli.total_duration.try_into().unwrap();
 
     for _ in 0..(target) {
-        // Loop until the elapsed time has reached the calculated total duration or event count has been reached
-        while duration.as_millis() < cli.total_duration.try_into().unwrap() && sent < cli.count {
+        // Additional duration condition to break out of the loop if total duration has been reached
+        if run_duration.as_millis() < t_duration {
             // Generate a random delay between 5 and 220ms
-            let pause_duration =
-                Duration::from_millis(random_num(cli.min_latency, cli.latency_max) as u64);
-
+            let pause_duration = Duration::from_millis(
+                rand::thread_rng().gen_range(cli.min_latency..cli.latency_max) as u64,
+            );
             let mut taken = 0;
             for ev in (&mut iter).take(cli.burst) {
                 let _ = channel_a
@@ -187,16 +183,17 @@ async fn app() -> anyhow::Result<()> {
                 break;
             }
             sent += taken;
-
             // Sleep for a randomly selected time
             tokio::time::sleep(pause_duration).await;
             // Stores the amount of time elapsed from the start.
-            duration = start.elapsed();
+            run_duration = start.elapsed();
+        } else {
+            break;
         }
     }
     println!(
         "Done! Total events sent: {}, total duration: {:?}",
-        sent, duration
+        sent, run_duration
     );
 
     Ok(())

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -18,11 +18,10 @@ use rand::{thread_rng, Rng};
 #[derive(Parser)]
 #[clap(about = "Generates random events and sends them over ampq")]
 struct Cli {
-
     // NOTE: The number of events along with the total duration, min lacency and latency max is to be used for stress testing.
     // When setting these values, keep in mind that the generator process will stop at whichever value is reached first (between the count and total duration).
     // The defaut settings on these variables represent roughly 30,000 events sent per hour.
- 
+
     // Total amount of events to be sent (note: multiplied with the `burst` option)
     #[clap(default_value = "30000", short, long)]
     count: usize,
@@ -96,18 +95,18 @@ async fn app() -> anyhow::Result<()> {
         )
         .await?;
 
-        // println!(?queue, "Declared queue");
+    // println!(?queue, "Declared queue");
     println!("Connected to broker.");
-    
+
     let gen = EventGenerator::new(
         cli.seed.unwrap_or_else(|| thread_rng().gen::<usize>()),
-        10,
-        11,
+        6,
+        8,
         EventSet::build()
             .add_link(Link::new("Link0", true))
             .add_link(Link::new("Link1", true))
             .add_event(
-                Event::new("Event" , "1.0.0")
+                Event::new("Event", "1.0.0")
                     .with_link("Link0")
                     .with_link("Link1"),
             )
@@ -128,10 +127,10 @@ async fn app() -> anyhow::Result<()> {
 
     let target = cli.count * cli.burst;
 
-    // Random number generator used to product random intervals 
-    fn random_num(from:usize, to:usize) -> usize{
+    // Random number generator used to product random intervals
+    fn random_num(from: usize, to: usize) -> usize {
         let mut rng = rand::thread_rng();
-        return rng.gen_range(from..to);
+        rng.gen_range(from..to)
     }
 
     println!(
@@ -145,39 +144,43 @@ async fn app() -> anyhow::Result<()> {
     // Decalred as mut in order to allow the value to change
     let mut duration = start.elapsed();
 
-        for _ in 0..(target) {
-            // Loop until the elapsed time has reached the calculated total duration or event count has been reached
-            while duration.as_millis() < cli.total_duration.try_into().unwrap() && sent < cli.count{
-                // Generate a random delay between 5 and 220ms
-                let pause_duration = Duration::from_millis(random_num(cli.min_latency, cli.latency_max) as u64);
+    for _ in 0..(target) {
+        // Loop until the elapsed time has reached the calculated total duration or event count has been reached
+        while duration.as_millis() < cli.total_duration.try_into().unwrap() && sent < cli.count {
+            // Generate a random delay between 5 and 220ms
+            let pause_duration =
+                Duration::from_millis(random_num(cli.min_latency, cli.latency_max) as u64);
 
-                let mut taken = 0;
-                for ev in (&mut iter).take(cli.burst) {
-                    let _ = channel_a
-                        .basic_publish(
-                            cli.exchange.as_str(),
-                            cli.routing_key.as_str(),
-                            BasicPublishOptions::default(),
-                            ev.as_slice(),
-                            BasicProperties::default(),
-                        )
-                        .await?
-                        .await?;
-                    taken += 1;
-                }
-                if cli.burst > taken {
-                    println!("Exhausted source, stopping early!");
-                    break;
-                }
-                sent += taken;
+            let mut taken = 0;
+            for ev in (&mut iter).take(cli.burst) {
+                let _ = channel_a
+                    .basic_publish(
+                        cli.exchange.as_str(),
+                        cli.routing_key.as_str(),
+                        BasicPublishOptions::default(),
+                        ev.as_slice(),
+                        BasicProperties::default(),
+                    )
+                    .await?
+                    .await?;
+                taken += 1;
+            }
+            if cli.burst > taken {
+                println!("Exhausted source, stopping early!");
+                break;
+            }
+            sent += taken;
 
-                // Sleep for a randomly selected time
-                tokio::time::sleep(pause_duration).await;
-                // Stores the amount of time elapsed from the start.
-                duration = start.elapsed();
+            // Sleep for a randomly selected time
+            tokio::time::sleep(pause_duration).await;
+            // Stores the amount of time elapsed from the start.
+            duration = start.elapsed();
         }
     }
-    println!("Done! Total events sent: {}, total duration: {:?}", sent, duration);
+    println!(
+        "Done! Total events sent: {}, total duration: {:?}",
+        sent, duration
+    );
 
     Ok(())
 }

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -100,8 +100,8 @@ async fn app() -> anyhow::Result<()> {
     
     let gen = EventGenerator::new(
         cli.seed.unwrap_or_else(|| thread_rng().gen::<usize>()),
-        4,
-        8,
+        10,
+        11,
         EventSet::build()
             .add_link(Link::new("Link0", true))
             .add_link(Link::new("Link1", true))


### PR DESCRIPTION
# Generator Modification 

## Description: 
  * Added Eiffel event list to the generator to allow for random event types
  * Changed the maximum amount of links per event to allow for a more realistic graph 
  * Added CLI arguments to allow for control over runtime and latency between events sent  
    * Arguments added: 

  | Argument name| Short name | Description | Default value|
  | ------------- | ------------- | ------------- | ------------- |
  | total_duration  | -t  | Total amount of time in milliseconds for the generator to run  |  3 600 000   |
  | min_latency  | -m  | Minimum value for the range of latency between events sent   |  5  |
  | latency_max  | -l  | Maximum value for the range of latency between events sent   |  220  |

## Useful notes:
* The default values of the CLI arguments (count, total_duration, min_latency and latency max ) are set to mimic roughly 30 000 events set per hour.
* The generator will run until either the count (total events to be sent) or the total_duration (duration for generator to run) has been reached.

## Screenshots:
Preview of random event types with random links:

![Screenshot 2022-10-14 195140](https://user-images.githubusercontent.com/81012809/195910189-e51a0d01-f8e1-4baf-a836-e6ec7d548350.png)



closes #13 
