### PR TITLE
Bug fix - When generating nodes without datadump

### DIFF
--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -16,11 +16,29 @@ use clap::Parser;
 use rand::{thread_rng, Rng};
 
 const EVENT_TYPES: [&str; 23] = [
-    "EiffelActivityStartedEvent", "EiffelActivityTriggeredEvent", "EiffelActivityCanceledEvent", "EiffelActivityFinishedEvent", "EiffelArtifactCreatedEvent", 
-    "EiffelArtifactPublishedEvent", "EiffelArtifactReusedEvent", "EiffelTestCaseStartedEvent", "EiffelTestCaseTriggeredEvent", "EiffelTestCaseCanceledEvent", 
-    "EiffelTestCaseFinishedEvent", "EiffelTestSuiteStartedEvent", "EiffelTestExecutionRecipeCollectionCreatedEvent", "EiffelTestSuiteFinishedEvent", 
-    "EiffelAnnouncementPublishedEvent", "EiffelCompositionDefinedEvent", "EiffelConfidenceLevelModifiedEvent", "EiffelEnvironmentDefinedEvent", 
-    "EiffelFlowContextDefinedEvent", "EiffelIssueDefinedEvent", "EiffelIssueVerifiedEvent", "EiffelSourceChangeCreatedEvent", "EiffelSourceChangeSubmittedEvent",
+    "EiffelActivityStartedEvent",
+    "EiffelActivityTriggeredEvent",
+    "EiffelActivityCanceledEvent",
+    "EiffelActivityFinishedEvent",
+    "EiffelArtifactCreatedEvent",
+    "EiffelArtifactPublishedEvent",
+    "EiffelArtifactReusedEvent",
+    "EiffelTestCaseStartedEvent",
+    "EiffelTestCaseTriggeredEvent",
+    "EiffelTestCaseCanceledEvent",
+    "EiffelTestCaseFinishedEvent",
+    "EiffelTestSuiteStartedEvent",
+    "EiffelTestExecutionRecipeCollectionCreatedEvent",
+    "EiffelTestSuiteFinishedEvent",
+    "EiffelAnnouncementPublishedEvent",
+    "EiffelCompositionDefinedEvent",
+    "EiffelConfidenceLevelModifiedEvent",
+    "EiffelEnvironmentDefinedEvent",
+    "EiffelFlowContextDefinedEvent",
+    "EiffelIssueDefinedEvent",
+    "EiffelIssueVerifiedEvent",
+    "EiffelSourceChangeCreatedEvent",
+    "EiffelSourceChangeSubmittedEvent",
 ];
 
 #[derive(Parser)]

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -16,8 +16,11 @@ use clap::Parser;
 use rand::{thread_rng, Rng};
 
 const EVENT_TYPES: [&str; 23] = [
-    "ActC", "ActF", "ActS", "ActT", "AnnP", "ArtC", "ArtP", "ArtR", "TCC", "TCF", "TCS", "TCT",
-    "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS",
+    "EiffelActivityStartedEvent", "EiffelActivityTriggeredEvent", "EiffelActivityCanceledEvent", "EiffelActivityFinishedEvent", "EiffelArtifactCreatedEvent", 
+    "EiffelArtifactPublishedEvent", "EiffelArtifactReusedEvent", "EiffelTestCaseStartedEvent", "EiffelTestCaseTriggeredEvent", "EiffelTestCaseCanceledEvent", 
+    "EiffelTestCaseFinishedEvent", "EiffelTestSuiteStartedEvent", "EiffelTestExecutionRecipeCollectionCreatedEvent", "EiffelTestSuiteFinishedEvent", 
+    "EiffelAnnouncementPublishedEvent", "EiffelCompositionDefinedEvent", "EiffelConfidenceLevelModifiedEvent", "EiffelEnvironmentDefinedEvent", 
+    "EiffelFlowContextDefinedEvent", "EiffelIssueDefinedEvent", "EiffelIssueVerifiedEvent", "EiffelSourceChangeCreatedEvent", "EiffelSourceChangeSubmittedEvent",
 ];
 
 #[derive(Parser)]


### PR DESCRIPTION
# Bug fix

## Description:
* Changed the names of the types for generated events to match the config.json file.
* This mismatch was causing event types not to be recognized and therefore not displayed.

resolves #37 