### PR TITLE
BUG FIX: Generator: number of sent events incorrect   

### DIFF
--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -101,12 +101,14 @@ async fn app() -> anyhow::Result<()> {
         Box::new(gen.iter())
     };
 
-    let target = cli.count * cli.burst;
+    let target = cli.count;
     let sleep_duration = Duration::from_millis(cli.latency as u64);
 
     println!(
         "Sending out ~{} events, {} events every {}ms interval",
-        target, cli.burst, cli.latency
+        target * cli.burst,
+        cli.burst,
+        cli.latency
     );
 
     let mut sent = 0;


### PR DESCRIPTION
# BUG FIX: Generator: number of sent events incorrect

## Description: 
* Generator sent out the incorrect number of events.
* This was caused by the fact that the main loop was iterating using the total number of events to be sent (count * burst) as the stop condition and not taking into account that the nested loop was iterating using the burst as a stop condition thus increasing the number of events sent by a factor of the burst, this is why it wasn't noticeable when the burst was set to it's default value of 1.   

## Screenshots:
Prior to fix: 
![Screenshot 2022-11-11 112149](https://user-images.githubusercontent.com/81012809/201320157-2af94bb6-ee41-4bda-aa8c-5c6444ae5ca4.png)

After fix:
![Screenshot 2022-11-11 112434](https://user-images.githubusercontent.com/81012809/201321095-8ba2ae9c-77e4-4974-94c1-06cac9914241.png)


## Testing:
* Ran with different values of both the count and burst to be sure the fix worked. 

resolves #27 