### PR TITLE
Fix: Filter Panel Overflow resolves #62

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -353,7 +353,7 @@ const displayInfoMessage= () =>{ //After 1 minute of no nodes recieved, a messag
   @tailwind components;
   @tailwind utilities;
   .show {
-    width: 320px;
+    width: 375px;
   }
   .move {
     margin-right: 350px;

--- a/frontend/src/components/ColorLegend.svelte
+++ b/frontend/src/components/ColorLegend.svelte
@@ -6,8 +6,8 @@
     import { defaultNode } from "../layout";
     const options = {
         container: "mountNode",
-        width: 280,
-        height: 220,
+        width: 335,
+        height: 210,
         workerEnabled: true,
         nodeSize: 20,
     };

--- a/frontend/src/components/Panel.svelte
+++ b/frontend/src/components/Panel.svelte
@@ -40,7 +40,7 @@
             <ColorLegend {styles} />
           </div>       
             <div
-              class="mt-auto pointer-events-auto bg-base-200 shadow-md rounded-r-lg overflow-y-scroll" 
+              class="mt-auto pointer-events-auto bg-base-200 shadow-md rounded-r-lg overflow-y-auto" 
               class:show={show_filter_panel}
               class:hidden={!show_filter_panel}
             >

--- a/frontend/src/components/Panel.svelte
+++ b/frontend/src/components/Panel.svelte
@@ -40,7 +40,7 @@
             <ColorLegend {styles} />
           </div>       
             <div
-              class="mt-auto pointer-events-auto bg-base-200 shadow-md rounded-r-lg" 
+              class="mt-auto pointer-events-auto bg-base-200 shadow-md rounded-r-lg overflow-y-scroll" 
               class:show={show_filter_panel}
               class:hidden={!show_filter_panel}
             >


### PR DESCRIPTION
# Description

Filter panel is now scrolling within and does not displace the whole app when overflowing

# Screenshots

<img width="1512" alt="Screenshot 2023-01-02 at 12 28 20" src="https://user-images.githubusercontent.com/71485862/210232030-c7843f12-7343-431e-a870-fbfbeda5ab2c.png">

resolves #62 
